### PR TITLE
Add Docker stack with FastAPI skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+REDIS_URL=redis://redis:6379/0
+DATABASE_URL=postgresql+psycopg2://postgres:postgres@postgres/postgres
+MONGO_URL=mongodb://mongo:27017
+CHROMA_HOST=chroma

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -110,13 +110,12 @@ POST /memory/semantic/add         → embed + store memory
 POST /trigger/emotion             → fire event trigger
 GET  /trigger/status              → check emotional state
 
-🔧 Setup (coming soon)
+🔧 Setup
 
-Docker Compose version
-
-.env example
-
-Container orchestration
+1. Install [Docker Compose](https://docs.docker.com/compose/install/).
+2. Copy `.env.example` to `.env` and adjust if needed.
+3. Run `docker compose up -d --build` to start all services.
+4. Visit `http://localhost:8000/docs` for the API docs.
 
 ❤️ Inspired by
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,102 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Any, Dict
+import os
+import redis
+from redis.exceptions import RedisError
+from motor.motor_asyncio import AsyncIOMotorClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
+import chromadb
+
+
+app = FastAPI(title="Josie AI Memory Stack")
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+POSTGRES_URL = os.environ.get("DATABASE_URL", "postgresql+psycopg2://postgres:postgres@localhost/postgres")
+MONGO_URL = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
+CHROMA_HOST = os.environ.get("CHROMA_HOST", "localhost")
+
+redis_client = redis.Redis.from_url(REDIS_URL)
+
+mongo_client = AsyncIOMotorClient(MONGO_URL)
+creative_db = mongo_client["creative"]
+
+engine = create_engine(POSTGRES_URL, future=True)
+
+# Attempt to connect to a Chroma server. Fallback to in-memory client during
+# tests or if the server is unavailable.
+try:
+    chroma_client = chromadb.HttpClient(host=CHROMA_HOST, port=8000)
+except Exception:
+    chroma_client = chromadb.Client()
+collection = chroma_client.get_or_create_collection("memory")
+
+@app.get("/", tags=["health"])
+async def read_root():
+    return {"status": "ok"}
+
+
+
+class TextPayload(BaseModel):
+    text: str
+
+class LongTermPayload(BaseModel):
+    id: str
+    data: Dict[str, Any]
+
+class CreativePayload(BaseModel):
+    tag: str
+    body: str
+
+class QueryPayload(BaseModel):
+    query: str
+
+
+@app.post("/memory/short-term")
+async def store_short_term(payload: TextPayload):
+    try:
+        redis_client.lpush("short_term", payload.text)
+        return {"status": "ok"}
+    except RedisError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/memory/short-term")
+async def get_short_term():
+    try:
+        messages = redis_client.lrange("short_term", 0, -1)
+        return {"memory": [m.decode("utf-8") for m in messages]}
+    except RedisError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/memory/long-term")
+async def add_long_term(payload: LongTermPayload):
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO ltm (id, data) VALUES (:id, :data)"),
+                {"id": payload.id, "data": payload.data},
+            )
+        return {"status": "ok"}
+    except SQLAlchemyError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/memory/creative")
+async def save_creative(payload: CreativePayload):
+    await creative_db.logs.insert_one(payload.dict())
+    return {"status": "ok"}
+
+
+@app.post("/memory/semantic/add")
+async def embed_memory(payload: TextPayload):
+    collection.add(documents=[payload.text], ids=[payload.text])
+    return {"status": "ok"}
+
+
+@app.post("/memory/semantic/query")
+async def search_memory(payload: QueryPayload):
+    results = collection.query(query_texts=[payload.query], n_results=5)
+    return results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+      - postgres
+      - mongo
+      - chroma
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@postgres/postgres
+      - MONGO_URL=mongodb://mongo:27017
+      - CHROMA_HOST=chroma
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  postgres:
+    image: ankane/pgvector
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+  mongo:
+    image: mongo:6
+    ports:
+      - "27017:27017"
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8001:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+redis
+psycopg2-binary
+motor
+chromadb
+SQLAlchemy
+pydantic
+python-dotenv

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- implement FastAPI server skeleton
- add Dockerfile and docker-compose.yml for stack services
- provide environment example
- add pytest test
- update README with Docker Compose setup instructions

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675fe96ab483249810a19adc0f59d1